### PR TITLE
fix Java 9 and 11 incompatibilities

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/devtech/grossfabrichacks/reflection/ReflectionUtil.java
+++ b/src/main/java/net/devtech/grossfabrichacks/reflection/ReflectionUtil.java
@@ -1,0 +1,91 @@
+package net.devtech.grossfabrichacks.reflection;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ReflectionUtil {
+    private static final ClassLoader LOADER = Thread.currentThread().getContextClassLoader();
+
+    private static final Method getDeclaredFields0 = getDeclaredMethod(Class.class, "getDeclaredFields0", boolean.class);
+
+    public static <T> T getDeclaredFieldValue(final String klass, final String name, final Object object) {
+        try {
+            return (T) getDeclaredField(klass, name).get(object);
+        } catch (IllegalAccessException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static <T> T getDeclaredFieldValue(final Class<?> klass, final String name, final Object object) {
+        try {
+            return (T) getDeclaredField(klass, name).get(object);
+        } catch (IllegalAccessException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static Field getDeclaredField(final String klass, final String name) {
+        try {
+            return getDeclaredField(Class.forName(klass, false, LOADER), name);
+        } catch (final ClassNotFoundException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static Field getDeclaredField(final Class<?> klass, final String name) {
+        final Field[] fields = getDeclaredFields0(klass, false);
+        final int fieldCount = fields.length;
+
+        for (int i = 0; i < fieldCount; i++) {
+            if (fields[i].getName().equals(name)) {
+                return fields[i];
+            }
+        }
+
+        throw new RuntimeException(String.format("field %s was not found in %s", name, klass.getName()));
+    }
+
+    public static Field[] getDeclaredFields0(final Class<?> klass, final boolean publicOnly) {
+        try {
+            return (Field[]) getDeclaredFields0.invoke(klass, publicOnly);
+        } catch (final IllegalAccessException | InvocationTargetException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static Method getDeclaredMethod(final String klass, final String name, final String... parameterTypes) {
+        final int parameterCount = parameterTypes.length;
+        final Class<?>[] parameterClasses = new Class<?>[parameterCount];
+
+        for (int i = 0; i < parameterCount; i++) {
+            try {
+                parameterClasses[i] = Class.forName(parameterTypes[i], false, LOADER);
+            } catch (final ClassNotFoundException exception) {
+                throw new RuntimeException(exception);
+            }
+        }
+
+        return getDeclaredMethod(klass, name, parameterClasses);
+    }
+
+    public static Method getDeclaredMethod(final String klass, final String name, final Class<?>... parameterTypes) {
+        try {
+            return getDeclaredMethod(Class.forName(klass, false, LOADER), name, parameterTypes);
+        } catch (final ClassNotFoundException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public static Method getDeclaredMethod(final Class<?> klass, final String name, final Class<?>... parameterTypes) {
+        try {
+            final Method method = klass.getDeclaredMethod(name, parameterTypes);
+
+            method.setAccessible(true);
+
+            return method;
+        } catch (final NoSuchMethodException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/src/main/java/net/fabricmc/loader/launch/knot/UnsafeKnotClassLoader.java
+++ b/src/main/java/net/fabricmc/loader/launch/knot/UnsafeKnotClassLoader.java
@@ -18,15 +18,15 @@ public class UnsafeKnotClassLoader extends KnotClassLoader {
     }
 
     public Class<?> defineClass(final String name, final byte[] bytes) {
-        final Class<?> klass = UnsafeUtil.defineClass(name, bytes, 0, bytes.length, null, null);
+        final Class<?> klass = UnsafeUtil.defineClass(name, bytes, null, null);
 
         DEFINED_CLASSES.put(name, klass);
 
         return klass;
     }
 
-    public Class<?> defineClass(final byte[] bytes, final int offset, final int length, final String name) {
-        final Class<?> klass = UnsafeUtil.defineClass(name, bytes, offset, length);
+    public Class<?> defineClass(final byte[] bytes, final String name) {
+        final Class<?> klass = UnsafeUtil.defineClass(name, bytes, null, null);
 
         DEFINED_CLASSES.put(name, klass);
 


### PR DESCRIPTION
bypass class field restriction to module from Java 9 or 11. Java 11 and above cannot utilize `UnsafeKnotClassLoader`'s full potential because `Unsafe::defineClass` is gone and the alternative (`JavaLangAccess::defineClass`) is inaccessible.